### PR TITLE
drop pure attribute for functions manipulating polymorphic entities

### DIFF
--- a/src/dag_module.F90
+++ b/src/dag_module.F90
@@ -116,7 +116,7 @@
 !>
 !  Constructor for [[edge]] type.
 
-    pure elemental function edge_constructor(ivertex,label,attributes,metadata) result(e)
+    impure elemental function edge_constructor(ivertex,label,attributes,metadata) result(e)
 
     integer(ip),intent(in),optional :: ivertex !! vertex number defining the destination of this edge
     character(len=*),intent(in),optional :: label !! vertex name for grahviz
@@ -388,11 +388,11 @@
 !>
 !  Returns the metadata for a vertex (node) in the dag.
 
-    pure function dag_get_vertex_metadata(me,ivertex) result(m)
+    function dag_get_vertex_metadata(me,ivertex) result(m)
 
     class(dag),intent(in) :: me
     integer(ip),intent(in) :: ivertex !! vertex number
-    class(*),allocatable :: m
+    class(*), allocatable :: m
 
     if (allocated(me%vertices(ivertex)%metadata)) &
         allocate(m, source = me%vertices(ivertex)%metadata)
@@ -404,7 +404,7 @@
 !>
 !  Returns the metadata for an edge in the dag.
 
-    pure function dag_get_edge_metadata(me,ivertex,iedge) result(m)
+    function dag_get_edge_metadata(me,ivertex,iedge) result(m)
 
     class(dag),intent(in) :: me
     integer(ip),intent(in) :: ivertex !! vertex number
@@ -1016,7 +1016,7 @@
 !>
 !  Swap two [[edge]] values.
 
-    pure elemental subroutine swap(i1,i2)
+    impure elemental subroutine swap(i1,i2)
 
     type(edge),intent(inout) :: i1
     type(edge),intent(inout) :: i2


### PR DESCRIPTION
The changes are necessary to allow building `daglib` with flang. Currently, using flang results in an errors similar to

```
$ FPM_FC=flang-new fpm build
[  0%]                 dag_module.F90
[ 50%]                 dag_module.F90  done.

error: Semantic errors in ././src/dag_module.F90
./././src/dag_module.F90:126:19: error: Result of pure function may not have polymorphic ALLOCATABLE ultimate component '%metadata'
      type(edge) :: e
                    ^
./././src/dag_module.F90:35:33: Declaration of 'metadata'
          class(*),allocatable :: metadata !! user-defined metadata
                                  ^^^^^^^^
<ERROR> Compilation failed for object " src_dag_module.F90.o "
<ERROR> stopping due to failed compilation
STOP 1
```

The issue is that polymorphic entities (or derived types containing polymorphic entities) when extended, could potentially result in impure behavior (e.g. an impure finalizer could be triggered).

